### PR TITLE
Fix DB_URL env variable

### DIFF
--- a/database.py
+++ b/database.py
@@ -2,12 +2,13 @@ import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./rssgpt.db")
+# Allow both DB_URL (as documented) and DATABASE_URL for backward compatibility
+DB_URL = os.getenv("DB_URL") or os.getenv("DATABASE_URL") or "sqlite:///./rssgpt.db"
 
 engine = create_engine(
-    DATABASE_URL,
-    connect_args={"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {},
-    echo=True
+    DB_URL,
+    connect_args={"check_same_thread": False} if DB_URL.startswith("sqlite") else {},
+    echo=True,
 )
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 


### PR DESCRIPTION
## Summary
- support `DB_URL` in `database.py` (match README)

## Testing
- `python -m py_compile app.py config.py database.py llm_summarizer.py fetch_articles.py init_db.py routers/*.py models.py schemas.py`
- `python init_db.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6851646339a883218271395a858b2b70